### PR TITLE
Test arbitrary mem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROGRAM ?= mem-latency
 
 
 $(PROGRAM): clean $(wildcard *.c) $(wildcard *.h) $(wildcard *.S)
-	$(CC) $(CFLAGS) $(LDFLAGS) -Xlinker --defsym=__heap_max=0x1 $(filter %.c %.S,$^) $(LOADLIBES) $(LDLIBS) -o $@
+	$(CC) $(CFLAGS) $(LDFLAGS) -Xlinker --defsym=__heap_max=0x1 $(filter %.c %.S,$^) $(LOADLIBES) $(LDLIBS) $(MEM_TEST_FLAGS) -o $@
 	riscv64-unknown-elf-objdump -d $@ > $@.dump
 
 clean:

--- a/README.md
+++ b/README.md
@@ -1,23 +1,22 @@
 # Introduction
 
-mem-latency is a micro-benchmark for detecting the memory sub-system micro-architecture.
-
-Currently, it can detect:
-
-* Number of memory hierarchy, e.g., L1, L2, L3, memory
+benchmark-mem-latency is a micro-benchmark for measureing the memory latency.
 
 # Setup
 
-clone benchmark-mem-latency under PATH-TO-FREEDOME-E-SDK/software
+Clone benchmark-mem-latency under PATH-TO-FREEDOME-E-SDK/software
 
-```
-git clone git@github.com:sifive/benchmark-mem-latency.git mem-latency
-```
-under PATH-TO-FREEDOME-E-SDK use followin command to compile & upload to arty
-```
-make software upload PROGRAM=mem-latency TARGET=design-arty
-```
+    git clone git@github.com:sifive/benchmark-mem-latency.git freedom-e-sdk/software/benchmark-mem-latency
 
+To build and run on the Arty FPGA board.
+
+    make -C freedom-e-sdk CONFIGURATION=release  PROGRAM=benchmark-mem-latency TARGET=design-arty clean software upload
+
+To build and run on verilator.
+
+    make -C freedom-e-sdk CONFIGURATION=release  PROGRAM=benchmark-mem-latency TARGET=design-rtl clean software
+    module load verilator/4.028
+    make benchmark-mem-latency.verilator.out
 
 # Result
 

--- a/latency_test.c
+++ b/latency_test.c
@@ -32,12 +32,17 @@ void rnd_init(void *test_setting) {
     setting->nptrs = setting->cur_range / setting->line;
     setting->ptrs = ptr_init_with_random(setting->nptrs - 1, setting->line);
 
-    if (setting->addr) {
+#ifndef TEST_ADDR
+    if (setting->addr)
         free(setting->addr);
-        setting->addr = NULL;
-    }
+#endif
+    setting->addr = NULL;
 
+#ifdef TEST_ADDR
+    register char *addr = setting->addr = (char *)TEST_ADDR;
+#else
     register char *addr = setting->addr = (char *)malloc(setting->max_range);
+#endif
 
     if (!setting->ptrs || !addr) {
         printf("malloc fail\n");

--- a/main.c
+++ b/main.c
@@ -50,16 +50,27 @@ void benchmark_latency(void *test_setting, size_t min_loop) {
 
 int main() {
     size_t heap_size = (size_t)(heap_end_location - heap_start_location);
+    // If TEST_ADDR is specified, by default this program tests the
+    // the heap memory, which is managed by malloc/free. So the test size is
+    // the available heap size.
+    // If TEST_ADDR is specified, it implies testing for non-heap memory.
+    // Therefore, the test_size will use TEST_SIZE, which should be given by an
+    // user.
+#ifdef TEST_ADDR
+    size_t test_size = (size_t)TEST_SIZE;
+#else
+    size_t test_size = heap_size;
+#endif
     struct test_info setting = {0};
     uint32_t test_count = 0;
     uint64_t cycle_count = 0;
     uint32_t i = 0, loop = 5, warmup_loop = 5;
     uint32_t all_test = sizeof(tests) / sizeof(tests[0]);
 
-    printf("heap size: %u K\n", (unsigned int)heap_size / 1024);
+    printf("test size: %u K\n", (unsigned int)test_size / 1024);
 
     while ((test_count < all_test) &&
-           (K_TO_BYTE(tests[test_count].size) < heap_size))
+           (K_TO_BYTE(tests[test_count].size) <= test_size))
         test_count++;
 
     if (test_count == 0) {

--- a/main.c
+++ b/main.c
@@ -50,7 +50,7 @@ void benchmark_latency(void *test_setting, size_t min_loop) {
 
 int main() {
     size_t heap_size = (size_t)(heap_end_location - heap_start_location);
-    // If TEST_ADDR is specified, by default this program tests the
+    // If TEST_ADDR is not specified, by default this program tests the
     // the heap memory, which is managed by malloc/free. So the test size is
     // the available heap size.
     // If TEST_ADDR is specified, it implies testing for non-heap memory.


### PR DESCRIPTION
Allow testing arbitrary memory by passing in the MEM_TEST_FLAGS to specify the memory address and size.

For example, to test latency at 0x70000000 with 4096 bytes, add the below param to make.

`MEM_TEST_FLAGS="-DTEST_ADDR=0x70000000 -DTEST_SIZE=4096"`

So the complete command will be:

`make -C freedom-e-sdk MEM_TEST_FLAGS="-DTEST_ADDR=0x70000000 -DTEST_SIZE=4096" CONFIGURATION=release PROGRAM=benchmark-mem-latency TARGET=design-rtl LINK_TARGET=default clean software`