### PR TITLE
Change the mem-latency default test size to 4KB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0 #
 
 PROGRAM ?= mem-latency
-
+# By default, it tests the latency of accessing the heap mem with 4096B.
+# To test the latency of accessing the max allocable heap mem, set TEST_SIZE to 0.
+# To test memory outside of the heap range, set both TEST_ADDR and TEST_SIZE.
+MEM_TEST_FLAGS ?= -DTEST_SIZE=4096
 
 $(PROGRAM): clean $(wildcard *.c) $(wildcard *.h) $(wildcard *.S)
 	$(CC) $(CFLAGS) $(LDFLAGS) -Xlinker --defsym=__heap_max=0x1 $(filter %.c %.S,$^) $(LOADLIBES) $(LDLIBS) $(MEM_TEST_FLAGS) -o $@

--- a/latency_test.c
+++ b/latency_test.c
@@ -41,6 +41,8 @@ void rnd_init(void *test_setting) {
 #ifdef TEST_ADDR
     register char *addr = setting->addr = (char *)TEST_ADDR;
 #else
+    // If TEST_ADDR is not specified, by default this program tests the
+    // the heap memory, which is managed by malloc/free.
     register char *addr = setting->addr = (char *)malloc(setting->max_range);
 #endif
 

--- a/main.c
+++ b/main.c
@@ -50,16 +50,15 @@ void benchmark_latency(void *test_setting, size_t min_loop) {
 
 int main() {
     size_t heap_size = (size_t)(heap_end_location - heap_start_location);
-    // If TEST_ADDR is not specified, by default this program tests the
-    // the heap memory, which is managed by malloc/free. So the test size is
-    // the available heap size.
-    // If TEST_ADDR is specified, it implies testing for non-heap memory.
-    // Therefore, the test_size will use TEST_SIZE, which should be given by an
-    // user.
-#ifdef TEST_ADDR
-    size_t test_size = (size_t)TEST_SIZE;
-#else
+    // If TEST_SIZE is 0, it will be the allocable heap size.
+    // Therefore, for testing mem devices not in the range covered by the
+    // heap memory, not only TEST_ADDR should be adjusted, TEST_SIZE
+    // should be adjusted as well since the size is irrelevant to the heap
+    // size.
+#if TEST_SIZE==0
     size_t test_size = heap_size;
+#else
+    size_t test_size = (size_t)TEST_SIZE;
 #endif
     struct test_info setting = {0};
     uint32_t test_count = 0;


### PR DESCRIPTION
This is for limiting the regression simulation time.

By default, it tests the latency of accessing the heap mem with 4096B.

To test the latency of accessing the max allocable heap mem, set TEST_SIZE to 0, as follows:

```
make -C freedom-e-sdk MEM_TEST_FLAGS="-DTEST_SIZE=0" CONFIGURATION=release PROGRAM=benchmark-mem-latency TARGET=design-rtl LINK_TARGET=default clean software
```

To test memory outside of the heap range, set both TEST_ADDR and TEST_SIZE.

```
make -C freedom-e-sdk MEM_TEST_FLAGS="-DTEST_ADDR=0x70000000 -DTEST_SIZE=4096" CONFIGURATION=release PROGRAM=benchmark-mem-latency TARGET=design-rtl LINK_TARGET=default clean software
```
